### PR TITLE
Issue #26 - Add favicon or image on page title bar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
       href="https://fonts.googleapis.com/css?family=Roboto&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" href="images/freeCodeCamp-logo.png" type="image/png" sizes="16x16">
     <title>freeCodeCamp Manila</title>
   </head>
 


### PR DESCRIPTION
Added Favicon reference tag for page title bar image. Needed to checkout actual develop master to avoid including commits from master. 

After: 
![2019-10-26_03-15-04](https://user-images.githubusercontent.com/8636946/67700368-ca1ae580-f9e8-11e9-91c8-bc5ce7454fe2.png)

Closes #26  

Cheers!