### PR TITLE
Enhancement: Set text-decoration to Underline on Hover

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -400,3 +400,7 @@ a.navbar-item:hover {
 .navbar-item + .navbar-item {
   margin: 0 1.125rem;
 }
+
+a.footer-link:hover {
+  text-decoration: underline;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
       href="https://fonts.googleapis.com/css?family=Roboto&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" href="images/freeCodeCamp-logo.png" type="image/png" sizes="16x16">
     <title>freeCodeCamp Manila</title>
   </head>
 


### PR DESCRIPTION
Hover on footer-link will set text-decoration to underline.

After change:

![2019-10-28_00-05-33](https://user-images.githubusercontent.com/8636946/67716767-5f2cd700-fa07-11e9-884d-3148d2a7c1b6.png)


Cheers!
