### PR TITLE
Fix text spacing on larger screens

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -217,6 +217,10 @@
 }
 
 /* ----------------- Hero section ----------------- */
+.hero {
+  padding-bottom: 8rem;
+}
+
 .hero .background-svg {
   width: 100%;
   top: 0;


### PR DESCRIPTION
**Description**

Fix community container spacing on larger screens. On larger screens, the text goes into the hero container.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/1100843/95217427-e5b87e00-083e-11eb-82f8-c47844ff298d.png)

After:
![image](https://user-images.githubusercontent.com/1100843/95217290-bf92de00-083e-11eb-8d4f-0c1e1085a704.png)

**Notes**

None
